### PR TITLE
Switch to self-hosted runners

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -16,7 +16,7 @@ defaults:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     services:
       postgres:
@@ -74,7 +74,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: test
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   
   docker:
     name: Docker
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: test
 
     steps:

--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -16,7 +16,7 @@ defaults:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: test
 
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   docker:
     name: Docker
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: test
 
     steps:


### PR DESCRIPTION
Change workflow setting yml to self-hosted runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configurations for both API and web releases to run on self-hosted environments instead of `ubuntu-latest`.
	- Maintained existing job structures and sequences while enhancing execution environments for improved resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->